### PR TITLE
Block searching

### DIFF
--- a/src/CinderBlockManager.cpp
+++ b/src/CinderBlockManager.cpp
@@ -44,11 +44,11 @@ CinderBlockManager::CinderBlockManager()
 {
 }
 
-void CinderBlockManager::scan( const QString &path, ErrorList *errors )
+void CinderBlockManager::scan(const QString &path, int depth, ErrorList *errors )
 {
 	QDir dir( path );
 	dir.setFilter( QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot );
-	inst()->scanAndParseCinderBlocks( dir, dir, 2, errors );
+	inst()->scanAndParseCinderBlocks( dir, dir, depth, errors );
 }
 
 CinderBlock* CinderBlockManager::findById( const QString &id )
@@ -56,7 +56,7 @@ CinderBlock* CinderBlockManager::findById( const QString &id )
 	for( QList<CinderBlock>::Iterator bIt = mCinderBlocks.begin(); bIt != mCinderBlocks.end(); ++bIt )
 		if( bIt->getId() == id )
 			return &(*bIt);
-	
+
 	return NULL;
 }
 
@@ -83,12 +83,12 @@ void CinderBlockManager::scanAndParseCinderBlocks( const QDir &cinderDir, const 
 			if( result ) {
 				pugi::xpath_node_set blocks = doc.select_nodes("/cinder/block");
 				for( pugi::xpath_node_set::const_iterator it = blocks.begin(); it != blocks.end(); ++it ) {
-					
+
 					QString relative = cinderDir.relativeFilePath( fileInfo.absoluteFilePath() );
 					errorList->setActiveFilePath( QString( "<a href=\"" ) + QUrl::fromLocalFile( fileInfo.absoluteFilePath() ).toString() + "\">" + relative + "</a>" );
-					
+
 					mCinderBlocks.push_back( CinderBlock( dir.absolutePath(), it->node(), errorList ) );
-					
+
 					// does this block have any templates?
 					pugi::xpath_node_set templates = doc.select_nodes( "/cinder/template" );
 					for( pugi::xpath_node_set::const_iterator it = templates.begin(); it != templates.end(); ++it ) {
@@ -110,7 +110,7 @@ void CinderBlockManager::scanAndParseCinderBlocks( const QDir &cinderDir, const 
 						}
 					}
 				}
-				
+
 				QFileInfo iconPath( dir, "cinderblock.png" );
 				if( iconPath.exists() ) {
 					mIconCache[iconPath.filePath()] = QIcon( iconPath.filePath() );
@@ -124,7 +124,7 @@ void CinderBlockManager::scanAndParseCinderBlocks( const QDir &cinderDir, const 
             }
 		}
 	}
-	
+
 	errorList->setActiveFilePath( "" );
 }
 
@@ -136,6 +136,6 @@ const QIcon& CinderBlockManager::getIconInst( const QString &path )
 	}
 	if( mIconCache.find( path ) != mIconCache.end() )
 		mIconCache[path] = QIcon( path );
-	
+
 	return mIconCache[path];
 }

--- a/src/CinderBlockManager.h
+++ b/src/CinderBlockManager.h
@@ -35,9 +35,9 @@ class CinderBlockManager
   public:
 	static const QList<CinderBlock>&		getCinderBlocks() { return inst()->mCinderBlocks; }
 	static const QList<ProjectTemplate>&	getProjectTemplates() { return inst()->mProjectTemplates; }
-	
+
 	//! add a directory to be scanned for CinderBlocks
-	static void		scan( const QString &path, ErrorList *errors );
+	static void		scan( const QString &path, int depth, ErrorList *errors );
 	static void		clear() { inst()->clearInst(); }
 	CinderBlock*	findById( const QString &id );
 

--- a/src/MainWizard.cpp
+++ b/src/MainWizard.cpp
@@ -91,7 +91,7 @@ void MainWizard::paintEvent( QPaintEvent */*event*/ )
 	QPainter painter( this );
 	QPixmap pmap(":/resources/background.png");
 	painter.setRenderHint( QPainter::SmoothPixmapTransform );
-	painter.setOpacity( 0.1f );	
+	painter.setOpacity( 0.1f );
 #if defined Q_OS_WIN
 	float scale = 0.5f;
 	int offset = 6;
@@ -275,8 +275,9 @@ void MainWizard::setCinderLocationByIndex( int index )
 {
 	mCinderLocationIndex = index;
 
-    auto const cinderLocationPath = Preferences::getCinderVersions()[index].path;
-    auto const blocksPath = cinderLocationPath + "/blocks";
+	auto const cinderLocationPath = Preferences::getCinderVersions()[index].path;
+	auto const blocksPath = cinderLocationPath + "/blocks";
+	auto const adjacentPath = cinderLocationPath + "/..";
 
 	ProjectTemplateManager::clear();
 	mTemplateErrors.clear();
@@ -284,7 +285,8 @@ void MainWizard::setCinderLocationByIndex( int index )
 
 	CinderBlockManager::clear();
 	mCinderBlockErrors.clear();
-    CinderBlockManager::scan( blocksPath, &mCinderBlockErrors );
+	CinderBlockManager::scan( blocksPath, 2, &mCinderBlockErrors );
+	CinderBlockManager::scan( adjacentPath, 1, &mCinderBlockErrors );
 
 	mCinderBlocks = CinderBlockManager::getCinderBlocks();
 

--- a/src/MainWizard.cpp
+++ b/src/MainWizard.cpp
@@ -275,7 +275,8 @@ void MainWizard::setCinderLocationByIndex( int index )
 {
 	mCinderLocationIndex = index;
 
-	auto cinderLocationPath = Preferences::getCinderVersions()[index].path;
+    auto const cinderLocationPath = Preferences::getCinderVersions()[index].path;
+    auto const blocksPath = cinderLocationPath + "/blocks";
 
 	ProjectTemplateManager::clear();
 	mTemplateErrors.clear();
@@ -283,7 +284,7 @@ void MainWizard::setCinderLocationByIndex( int index )
 
 	CinderBlockManager::clear();
 	mCinderBlockErrors.clear();
-	CinderBlockManager::scan( cinderLocationPath, &mCinderBlockErrors );
+    CinderBlockManager::scan( blocksPath, &mCinderBlockErrors );
 
 	mCinderBlocks = CinderBlockManager::getCinderBlocks();
 


### PR DESCRIPTION
Search for cinder blocks in directory adjacent to Cinder version as well as the `blocks` directory.

Makes using Cinder and blocks as submodules of a larger project more convenient.

QtCreator cleaned up some trailing whitespace.

Almost solves issue #1. Punts on adding gui elements while supporting what (for me) is a very handy use-case.
