### PR TITLE
make 'Preferences' dialog user-friendly

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -123,7 +123,7 @@ void Preferences::updateCinderVersionInst( size_t index, const QString &name, co
 ////////////////////////////////////////////////////////////////////////////////////////////
 // Preferences
 Prefs::Prefs(QWidget *parent)
-: QDialog( parent, Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowCloseButtonHint ),
+: QDialog( parent ),
   ui( new Ui::Prefs )
 {
     ui->setupUi(this);

--- a/ui/PrefsDlg.ui
+++ b/ui/PrefsDlg.ui
@@ -136,6 +136,19 @@
          </property>
         </spacer>
        </item>
+       <item>
+        <widget class="QPushButton" name="okButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>OK</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
     </layout>
@@ -145,5 +158,22 @@
  <resources>
   <include location="../TinderBox.qrc"/>
  </resources>
- <connections/>
+ <connections>
+  <connection>
+   <sender>okButton</sender>
+   <signal>clicked()</signal>
+   <receiver>Prefs</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>525</x>
+     <y>314</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>168</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
The only way to close it is to push `ESC` on keyboard.

This PR will:
* enable close button in top right corner
* add simple 'OK' button that will accept dialog (hide it)

Before:
![image](https://cloud.githubusercontent.com/assets/6915328/22759109/8de8ac00-ee51-11e6-9f65-15b04d13bbf8.png)

After:
![image](https://cloud.githubusercontent.com/assets/6915328/22759128/9770ca82-ee51-11e6-8319-5cc1d9c12b13.png)
