### PR TITLE
select x64 platform by default in VS2013 env configuration

### DIFF
--- a/ui/WizardPageEnvOptions.ui
+++ b/ui/WizardPageEnvOptions.ui
@@ -239,6 +239,9 @@
            <property name="text">
             <string>x64</string>
            </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
           </widget>
          </item>
         </layout>


### PR DESCRIPTION
* x64 option will now be selected by default for Visual Studio 2013 environment

![image](https://cloud.githubusercontent.com/assets/6915328/22904910/73d5e882-f23e-11e6-8310-e9b37a96ca8f.png)
